### PR TITLE
Fix KeyError parsing .eso variables reported under a schedule (#19)

### DIFF
--- a/db_eplusout_reader/processing/esofile_reader.py
+++ b/db_eplusout_reader/processing/esofile_reader.py
@@ -21,6 +21,13 @@ ANNUAL_LINE = 6
 
 Variable = namedtuple("Variable", "key type units")
 
+# Compiled once (rather than per line) to avoid repeated recompilation.
+# The trailing '(?:,(.*))?' captures an optional schedule name emitted for
+# variables reported under a schedule (conditional reporting), e.g.:
+#     276,1,BLOCK1:ZONE1,Zone Mean Air Temperature [C] !Hourly,ON
+# The schedule name is parsed but does not take part in variable identity.
+HEADER_PATTERN = re.compile(r"^(\d+),(\d+),(.*?)(?:,(.*?) ?\[| ?\[)(.*?)\] !(\w*)(?:,(.*))?")
+
 
 def get_eso_file_version(raw_version):
     """Return eso file version as an integer (i.e.: 860, 890)."""
@@ -62,10 +69,10 @@ def process_header_line(line):
         Processed line tuple (ID, key name, variable name, units, frequency)
 
     """
-    pattern = re.compile(r"^(\d+),(\d+),(.*?)(?:,(.*?) ?\[| ?\[)(.*?)\] !(\w*)")
-
     # this raises attribute error when there's some unexpected line syntax
-    raw_line_id, _, key, type_, units, frequency = pattern.search(line).groups()
+    raw_line_id, _, key, type_, units, frequency, _schedule = HEADER_PATTERN.search(
+        line
+    ).groups()
     line_id = int(raw_line_id)
 
     # 'type' variable is 'None' for 'Meter' variable
@@ -91,11 +98,22 @@ def read_header(eso_file):
 
     Returns
     -------
-    dict of {str : dict of {Variable : int}}
-        A dictionary of eso file header line with populated values.
+    tuple of (dict, dict)
+        ``header`` mapping {str : dict of {Variable : int}} used for variable
+        matching, and ``all_ids`` mapping {str : list of int} holding every
+        line id seen for each frequency.
+
+    Note
+    ----
+    Two dictionary lines can collapse to the same ``Variable`` when they only
+    differ by a schedule name (conditional reporting). The ``header`` dict
+    keeps a single id per ``Variable`` (last one wins), but every id is still
+    emitted in the body, so ``all_ids`` is tracked separately to ensure the
+    output bins cover all of them and the body parser never hits a missing id.
 
     """
     header = defaultdict(partial(defaultdict))
+    all_ids = defaultdict(list)
     while True:
         raw_line = next(eso_file)
         try:
@@ -107,7 +125,8 @@ def read_header(eso_file):
                 raise BlankLineError("Empty line!")
             raise InvalidLineSyntax("Unexpected line syntax: '{}'!".format(raw_line))
         header[frequency][Variable(key, type_, units)] = line_id
-    return header
+        all_ids[frequency].append(line_id)
+    return header, all_ids
 
 
 def process_ts_h_d_frequency_line(line_id, data):
@@ -209,11 +228,11 @@ def split_raw_line(raw_line):
     return line_id, line
 
 
-def process_frequency_line(line_id, line, all_raw_outputs, header, raw_outputs):
+def process_frequency_line(line_id, line, all_raw_outputs, header, all_ids, raw_outputs):
     if line_id == ENVIRONMENT_LINE:
         # initialize variables for current environment
         environment_name = line[0].strip()
-        raw_outputs = RawOutputData(environment_name, header)
+        raw_outputs = RawOutputData(environment_name, header, all_ids)
         all_raw_outputs.append(raw_outputs)
         frequency = None
     else:
@@ -234,7 +253,7 @@ def process_frequency_line(line_id, line, all_raw_outputs, header, raw_outputs):
     return raw_outputs, frequency
 
 
-def read_body(eso_file, highest_frequency_id, header):
+def read_body(eso_file, highest_frequency_id, header, all_ids):
     """
     Read body of the eso file.
 
@@ -270,7 +289,7 @@ def read_body(eso_file, highest_frequency_id, header):
             # distribute outputs into relevant bins
             if line_id <= highest_frequency_id:
                 raw_outputs, frequency = process_frequency_line(
-                    line_id, line, all_raw_outputs, header, raw_outputs
+                    line_id, line, all_raw_outputs, header, all_ids, raw_outputs
                 )
             else:
                 # current line represents a result, replace nan values from the last step
@@ -299,10 +318,10 @@ def read_file(file):
 
     # Read header to obtain a header dictionary of EnergyPlus
     # outputs and initialize dictionary for output values
-    header = read_header(file)
+    header, all_ids = read_header(file)
 
     # Read body to obtain outputs and environment dictionaries
-    return read_body(file, last_standard_item_id, header)
+    return read_body(file, last_standard_item_id, header, all_ids)
 
 
 def process_eso_file(file_path):

--- a/db_eplusout_reader/processing/raw_eso_data.py
+++ b/db_eplusout_reader/processing/raw_eso_data.py
@@ -4,9 +4,19 @@ from db_eplusout_reader.constants import RP, A, M
 
 
 class RawOutputData:
-    def __init__(self, environment_name, header):
+    def __init__(self, environment_name, header, all_ids=None):
         self.environment_name = environment_name
         self.header = header
+        # ``all_ids`` holds every line id per frequency, including ids that
+        # collapse to the same Variable in ``header`` (e.g. a variable reported
+        # both with and without a schedule). Output bins must cover all of them
+        # so the body parser never encounters an unregistered id. Fall back to
+        # the header ids when ``all_ids`` is not supplied.
+        if all_ids is None:
+            all_ids = {
+                frequency: list(variables.values()) for frequency, variables in header.items()
+            }
+        self.all_ids = all_ids
         (
             self.outputs,
             self.dates,
@@ -19,13 +29,13 @@ class RawOutputData:
         dates = {}
         cumulative_days = {}
         days_of_week = {}
-        for frequency, variables in self.header.items():
+        for frequency, ids in self.all_ids.items():
             dates[frequency] = []
             if frequency in (M, A, RP):
                 cumulative_days[frequency] = []
             else:
                 days_of_week[frequency] = []
-            for id_ in variables.values():
+            for id_ in ids:
                 outputs[frequency][id_] = []
         return outputs, dates, cumulative_days, days_of_week
 

--- a/tests/test_esofile_reader.py
+++ b/tests/test_esofile_reader.py
@@ -71,3 +71,47 @@ class TestEsofileReaderErrors:
         result = process_eso_file(str(eso))
         assert len(result) == 1
         assert result[0].environment_name == "TEST ENV"
+
+
+class TestScheduleReference:
+    """Variables reported under a schedule carry a trailing schedule name in
+    the dictionary line, e.g. '... [C] !Hourly,ON'. When the same variable is
+    reported both with and without a schedule the two dictionary lines collapse
+    to one Variable, but both ids still appear in the body. This used to raise
+    KeyError (issue #19); every id must be registered in the output bins.
+    """
+
+    def test_schedule_suffix_is_parsed(self):
+        from db_eplusout_reader.processing.esofile_reader import process_header_line
+
+        line = "276,1,BLOCK1:ZONE1,Zone Mean Air Temperature [C] !Hourly,ON"
+        line_id, key, type_, units, frequency = process_header_line(line)
+        assert line_id == 276
+        assert key == "BLOCK1:ZONE1"
+        assert type_ == "Zone Mean Air Temperature"
+        assert units == "C"
+        assert frequency == "hourly"
+
+    def test_duplicate_variable_with_and_without_schedule(self, tmp_path):
+        # 275 (no schedule) and 276 (schedule 'ON') share the same Variable.
+        header = _HEADER + (
+            "275,1,BLOCK1:ZONE1,Zone Mean Air Temperature [C] !Hourly\n"
+            "276,1,BLOCK1:ZONE1,Zone Mean Air Temperature [C] !Hourly,ON\n"
+        )
+        body = (
+            "End of Data Dictionary\n"
+            "1,TEST ENV, 0.0, 0.0, 0.0, 0.0\n"
+            "2,1, 1, 1, 0, 1, 0.00,60.00,Tuesday\n"
+            "7,20.0\n"
+            "275,21.0\n"
+            "276,22.0\n"
+            "End of Data\n"
+        )
+        eso = tmp_path / "schedule.eso"
+        eso.write_text(header + body)
+
+        result = process_eso_file(str(eso))  # must not raise KeyError
+
+        outputs = result[0].outputs["hourly"]
+        assert outputs[275] == [21.0]
+        assert outputs[276] == [22.0]


### PR DESCRIPTION
## Summary

Fixes #19 — `get_results(...)` raised `KeyError` while parsing any `.eso` containing an `Output:Variable` reported under a schedule (conditional reporting).

## Root cause

EnergyPlus emits a trailing schedule name on the dictionary line for schedule-gated variables:

```
275,1,BLOCK1:ZONE1,Zone Mean Air Temperature [C] !Hourly
276,1,BLOCK1:ZONE1,Zone Mean Air Temperature [C] !Hourly,ON
```

The parser drops the schedule suffix, so both lines collapse to the same `Variable(key, type, units)`. The header dict (`{Variable: id}`) is last-write-wins, so one `line_id` was lost — but **both** ids still appear in the body. When the body emitted the dropped id, `outputs[frequency][line_id]` raised `KeyError`.

## Fix

- `read_header` now also returns `all_ids` — `{frequency: [every line_id]}` — alongside the deduped matching header.
- `RawOutputData` initializes its output bins from `all_ids`, so **every** body id is registered and the parser never hits a missing id.
- The matching header stays keyed on `(key, type, units)`, so the public API and variable matching are unchanged.
- The header regex is now compiled **once** at module level (per @voightp's note) and captures — but ignores — the optional schedule name.

The schedule name is parsed but deliberately not part of variable identity: the body already encodes which hours are reported.

## Tests

Added `TestScheduleReference` in `tests/test_esofile_reader.py`:
- `test_schedule_suffix_is_parsed` — the `,ON` suffix parses without disturbing key/type/units/frequency.
- `test_duplicate_variable_with_and_without_schedule` — reproduces the exact crash and asserts both ids retain their values.

Full suite: **125 passed**; `ruff check` and `ruff format --check` clean.

## Note / follow-up

This returns one series per `(key, type, units)`. Exposing duplicate variables that differ *only* by schedule (the design question @voightp raised) would require adding a `schedule` field to the public `Variable` namedtuple — a breaking change — so it's left as a possible future enhancement rather than bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
