### PR TITLE
Fix meter results returning key='None' for NULL KeyValue (#12)

### DIFF
--- a/db_eplusout_reader/sql_reader.py
+++ b/db_eplusout_reader/sql_reader.py
@@ -87,8 +87,14 @@ def fetch_data_dict_rows(conn, variable, sql_frequency, alike):
 
 
 def to_string(unicode_variable):
-    """Convert variable unicode field names to string field names."""
-    return Variable(*map(lambda x: str(x), unicode_variable))
+    """Convert variable unicode field names to string field names.
+
+    Since EnergyPlus 23.1 the ``KeyValue`` of meter outputs is stored as
+    ``NULL`` instead of an empty string. A ``None`` field is normalized to an
+    empty string so meters present a ``key`` of ``""`` (as before) rather than
+    the literal string ``"None"``.
+    """
+    return Variable(*("" if x is None else str(x) for x in unicode_variable))
 
 
 def get_unsorted_sub_dict(rows):

--- a/tests/test_sql_results.py
+++ b/tests/test_sql_results.py
@@ -92,6 +92,16 @@ class TestSql:
         assert len(results) == 1
         assert len(list(results.values())[0]) > 0
 
+    def test_meter_null_keyvalue_is_empty_string(self, sql_path):
+        # Since EnergyPlus 23.1 meter KeyValue is stored as NULL. The returned
+        # Variable key must be an empty string, not the literal "None" (#12).
+        results = get_results(
+            sql_path, Variable(None, "EnergyTransfer:Facility", "J"), frequency=H
+        )
+        assert len(results) == 1
+        assert results.first_variable.key == ""
+        assert len(results.first_array) > 0
+
     def test_results_time_series(self, sql_path):
         variable = Variable("ZONE ONE", "Zone Other Equipment Total Heating Energy", "J")
         for frequency, expected in zip([RP, M, D, H], [3, 14, 367, 8808]):


### PR DESCRIPTION
## Summary

Fixes #12 — meter results came back with the literal string `key='None'`.

Since EnergyPlus 23.1, the `KeyValue` of meter outputs is stored as `NULL` in the `.sql` file instead of an empty string. `to_string()` mapped `str()` over every field, so a `NULL` KeyValue surfaced as the string `"None"`:

```python
Variable(key='None', type='EnergyTransfer:Facility', units='J')   # before
Variable(key='',     type='EnergyTransfer:Facility', units='J')   # after
```

## Fix

`to_string()` now normalizes a `None` field to an empty string, restoring the prior meter representation (`key=""`). Wildcard matching with `Variable(None, ...)` is unaffected — `None` fields are still skipped in the query builder.

## Tests

Added `test_meter_null_keyvalue_is_empty_string` asserting a meter request returns `key == ""` with non-empty data. Full suite green; `ruff check` / `format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
