### PR TITLE
Add strict flag to raise when a requested variable is missing (#18)

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,14 @@ results = get_results(path, variables, frequency=D, alike=True)
 # Variable("BLOCK", None, None) will match "PEOPLE BLOCK1:ZONE2"
 ```
 
+**Strict Mode**
+
+```python
+# By default, requested variables that aren't present are silently skipped.
+# Pass strict=True to raise VariableNotFound instead.
+results = get_results(path, variables, frequency=D, strict=True)
+```
+
 **Date Range Filtering**
 
 ```python

--- a/db_eplusout_reader/db_esofile.py
+++ b/db_eplusout_reader/db_esofile.py
@@ -1,5 +1,5 @@
 from db_eplusout_reader.constants import RP, TS, A, D, H, M
-from db_eplusout_reader.exceptions import CollectionRequired
+from db_eplusout_reader.exceptions import CollectionRequired, raise_if_missing
 from db_eplusout_reader.processing.esofile_reader import Variable, process_eso_file
 from db_eplusout_reader.processing.esofile_time import (
     convert_raw_date_data,
@@ -120,7 +120,9 @@ class DBEsoFile:
         order = {TS: 0, H: 1, D: 2, M: 3, A: 4, RP: 5}
         return sorted(list(self.header.keys()), key=lambda x: order[x])
 
-    def get_results(self, variables, frequency, alike=False, start_date=None, end_date=None):
+    def get_results(
+        self, variables, frequency, alike=False, start_date=None, end_date=None, strict=False
+    ):
         """
         Extract results from the parsed ESO file data.
 
@@ -137,6 +139,9 @@ class DBEsoFile:
             Lower datetime interval boundary, inclusive.
         end_date : default None, datetime.datetime
             Upper datetime interval boundary, inclusive.
+        strict : default False, bool
+            When True, raise VariableNotFound if any requested variable
+            does not match an output in the file.
 
         Returns
         -------
@@ -149,7 +154,9 @@ class DBEsoFile:
         freq_dates = self.dates.get(frequency, [])
 
         rd = ResultsDictionary(frequency)
-        matched_vars = self._match_variables(variables, freq_header, alike)
+        matched_vars, not_found = self._match_variables(variables, freq_header, alike)
+        if strict:
+            raise_if_missing(not_found)
 
         for var, var_id in matched_vars.items():
             values = freq_outputs.get(var_id, [])
@@ -167,13 +174,22 @@ class DBEsoFile:
         return rd
 
     def _match_variables(self, variables, freq_header, alike):
-        """Find matching variables from the header based on filter criteria."""
+        """Find matching variables from the header based on filter criteria.
+
+        Returns the matched {Variable : id} mapping and the list of requested
+        variables that did not match any header variable.
+        """
         matched = {}
+        not_found = []
         for req_var in variables:
+            found = False
             for header_var, var_id in freq_header.items():
                 if self._variable_matches(req_var, header_var, alike):
                     matched[header_var] = var_id
-        return matched
+                    found = True
+            if not found:
+                not_found.append(req_var)
+        return matched, not_found
 
     def _variable_matches(self, request, header, alike):
         """Check if a header variable matches the requested variable."""

--- a/db_eplusout_reader/db_esofile.py
+++ b/db_eplusout_reader/db_esofile.py
@@ -154,16 +154,12 @@ class DBEsoFile:
         freq_dates = self.dates.get(frequency, [])
 
         rd = ResultsDictionary(frequency)
-        matched_vars, not_found = self._match_variables(variables, freq_header, alike)
-        if strict:
-            raise_if_missing(not_found)
+        matched_vars = self._match_variables(variables, freq_header, alike, strict)
 
         for var, var_id in matched_vars.items():
             values = freq_outputs.get(var_id, [])
             if start_date or end_date:
-                values, filtered_dates = self._filter_by_date(
-                    values, freq_dates, start_date, end_date
-                )
+                values, _ = self._filter_by_date(values, freq_dates, start_date, end_date)
             rd[var] = values
 
         if start_date or end_date:
@@ -173,11 +169,11 @@ class DBEsoFile:
 
         return rd
 
-    def _match_variables(self, variables, freq_header, alike):
+    def _match_variables(self, variables, freq_header, alike, strict=False):
         """Find matching variables from the header based on filter criteria.
 
-        Returns the matched {Variable : id} mapping and the list of requested
-        variables that did not match any header variable.
+        When ``strict`` is True, raise VariableNotFound if any requested
+        variable does not match a header variable.
         """
         matched = {}
         not_found = []
@@ -189,7 +185,9 @@ class DBEsoFile:
                     found = True
             if not found:
                 not_found.append(req_var)
-        return matched, not_found
+        if strict:
+            raise_if_missing(not_found)
+        return matched
 
     def _variable_matches(self, request, header, alike):
         """Check if a header variable matches the requested variable."""

--- a/db_eplusout_reader/exceptions.py
+++ b/db_eplusout_reader/exceptions.py
@@ -26,5 +26,19 @@ class NoResults(Exception):
     """Exception raised when numeric outputs are requsted in empty results dictionary."""
 
 
+class VariableNotFound(Exception):
+    """Exception raised in strict mode when a requested variable is not present."""
+
+
+def raise_if_missing(not_found):
+    """Raise VariableNotFound listing any requested variables without a match."""
+    if not_found:
+        raise VariableNotFound(
+            "Requested variable(s) not found: {}".format(
+                ", ".join(repr(variable) for variable in not_found)
+            )
+        )
+
+
 class InvalidShape(Exception):
     """Exception raised when table does not have uniform number of items in each column."""

--- a/db_eplusout_reader/get_results.py
+++ b/db_eplusout_reader/get_results.py
@@ -5,7 +5,13 @@ from db_eplusout_reader.sql_reader import get_results_from_sql
 
 
 def get_results(
-    file_or_path, variables, frequency, alike=False, start_date=None, end_date=None
+    file_or_path,
+    variables,
+    frequency,
+    alike=False,
+    start_date=None,
+    end_date=None,
+    strict=False,
 ):
     r"""
     Extract results from given file.
@@ -92,6 +98,9 @@ def get_results(
         Lower datetime interval boundary, inclusive.
     end_date : default None, datetime.datetime
         Upper datetime interval boundary, inclusive.
+    strict : default False, bool
+        When True, raise VariableNotFound if any requested variable
+        does not match an output in the file.
 
     Returns
     -------
@@ -109,6 +118,7 @@ def get_results(
                 alike=alike,
                 start_date=start_date,
                 end_date=end_date,
+                strict=strict,
             )
         elif ext == ".eso":
             eso_file = DBEsoFile.from_path(file_or_path)
@@ -118,6 +128,7 @@ def get_results(
                 alike=alike,
                 start_date=start_date,
                 end_date=end_date,
+                strict=strict,
             )
         else:
             raise TypeError(f"Unsupported file type '{ext}' provided!")
@@ -128,6 +139,7 @@ def get_results(
             alike=alike,
             start_date=start_date,
             end_date=end_date,
+            strict=strict,
         )
     elif isinstance(file_or_path, DBEsoFileCollection):
         raise TypeError(

--- a/db_eplusout_reader/sql_reader.py
+++ b/db_eplusout_reader/sql_reader.py
@@ -4,6 +4,7 @@ from collections import OrderedDict
 from datetime import datetime, timedelta
 
 from db_eplusout_reader.constants import RP, TS, A, D, H, M
+from db_eplusout_reader.exceptions import raise_if_missing
 from db_eplusout_reader.processing.esofile_reader import Variable
 from db_eplusout_reader.results_dict import ResultsDictionary
 
@@ -109,13 +110,20 @@ def sort_by_value(unsorted_dict):
 
 
 def get_ids_dict(conn, variables, sql_frequency, alike):
-    """Find id : Variable pairs for given 'Variable' request."""
+    """Find id : Variable pairs for given 'Variable' request.
+
+    Returns the id : Variable mapping and the list of requested variables
+    that did not match any output.
+    """
     all_ids_dict = OrderedDict()
+    not_found = []
     for variable in variables:
         rows = fetch_data_dict_rows(conn, variable, sql_frequency, alike)
         ids_dict = get_unsorted_sub_dict(rows)
+        if not ids_dict:
+            not_found.append(variable)
         all_ids_dict.update(sort_by_value(ids_dict))
-    return all_ids_dict
+    return all_ids_dict, not_found
 
 
 def validate_time(timestamp, start_date, end_date):
@@ -226,7 +234,7 @@ def get_timestamps_from_sql(path, frequency, start_date=None, end_date=None):
 
 
 def get_results_from_sql(
-    path, variables, frequency, alike=False, start_date=None, end_date=None
+    path, variables, frequency, alike=False, start_date=None, end_date=None, strict=False
 ):
     """
     Extract output values from given EnergyPlus .sql file.
@@ -246,6 +254,9 @@ def get_results_from_sql(
         Lower datetime interval boundary, inclusive.
     end_date : default None, datetime.datetime
         Upper datetime interval boundary, inclusive.
+    strict : default False, bool
+        When True, raise VariableNotFound if any requested variable
+        does not match an output in the file.
 
     Returns
     -------
@@ -257,7 +268,10 @@ def get_results_from_sql(
     conn = sqlite3.connect(path)
     variables = [variables] if isinstance(variables, Variable) else variables
     sql_frequency = to_sql_frequency(frequency)
-    ids_dict = get_ids_dict(conn, variables, sql_frequency, alike)
+    ids_dict, not_found = get_ids_dict(conn, variables, sql_frequency, alike)
+    if strict and not_found:
+        conn.close()
+        raise_if_missing(not_found)
     rd = ResultsDictionary(frequency)
     for id_, variable in ids_dict.items():
         if start_date or end_date:

--- a/tests/test_eso_file.py
+++ b/tests/test_eso_file.py
@@ -14,6 +14,7 @@ import pytest
 from db_eplusout_reader import Variable, get_results
 from db_eplusout_reader.constants import RP, D, H, M
 from db_eplusout_reader.db_esofile import DBEsoFile, DBEsoFileCollection
+from db_eplusout_reader.exceptions import VariableNotFound
 
 # Variable present in all versioned 1ZoneUncontrolled files
 _DRYBULB = Variable("Environment", "Site Outdoor Air Drybulb Temperature", "C")
@@ -76,6 +77,27 @@ class TestEsoGetResults:
 
         assert len(results.time_series) == 8760
         assert isinstance(results.time_series[0], datetime)
+
+
+class TestEsoStrict:
+    _MISSING = Variable("NOPE", "Does Not Exist", "X")
+
+    def test_strict_present_variable_ok(self, session_eso_file):
+        results = session_eso_file.get_results([_DRYBULB], H, strict=True)
+        assert len(results) == 1
+
+    def test_strict_missing_variable_raises(self, session_eso_file):
+        with pytest.raises(VariableNotFound, match="Does Not Exist"):
+            session_eso_file.get_results([_DRYBULB, self._MISSING], H, strict=True)
+
+    def test_non_strict_missing_variable_ignored(self, session_eso_file):
+        results = session_eso_file.get_results([_DRYBULB, self._MISSING], H)
+        assert len(results) == 1
+
+    def test_strict_missing_frequency_raises(self, session_eso_file):
+        # frequency with no matching variable for the request
+        with pytest.raises(VariableNotFound):
+            session_eso_file.get_results([self._MISSING], H, strict=True)
 
     def test_get_results_no_match(self, session_eso_file):
         variables = [Variable("NonExistent", "Variable", "X")]

--- a/tests/test_sql_results.py
+++ b/tests/test_sql_results.py
@@ -13,6 +13,7 @@ import pytest
 
 from db_eplusout_reader import Variable, get_results
 from db_eplusout_reader.constants import RP, TS, A, D, H, M
+from db_eplusout_reader.exceptions import VariableNotFound
 from db_eplusout_reader.results_dict import ResultsHandler
 from db_eplusout_reader.sql_reader import (
     get_timestamps_from_sql,
@@ -112,6 +113,26 @@ class TestSql:
         with pytest.raises(IOError):
             get_results(invalid_path, variables=variable, frequency=H)
         assert not os.path.exists(invalid_path)
+
+
+class TestSqlStrict:
+    _MISSING = Variable("NOPE", "Does Not Exist", "X")
+
+    def test_strict_present_variable_ok(self, sql_path):
+        results = get_results(sql_path, _DRYBULB, frequency=H, strict=True)
+        assert len(results) == 1
+
+    def test_strict_missing_variable_raises(self, sql_path):
+        with pytest.raises(VariableNotFound):
+            get_results(sql_path, [_DRYBULB, self._MISSING], frequency=H, strict=True)
+
+    def test_non_strict_missing_variable_ignored(self, sql_path):
+        results = get_results(sql_path, [_DRYBULB, self._MISSING], frequency=H)
+        assert len(results) == 1
+
+    def test_strict_message_lists_missing(self, sql_path):
+        with pytest.raises(VariableNotFound, match="Does Not Exist"):
+            get_results(sql_path, self._MISSING, frequency=H, strict=True)
 
 
 class TestSqlInternals:


### PR DESCRIPTION
## Summary

Implements #18 — an opt-in `strict` flag so callers can fail loudly when a requested variable isn't in the file, instead of getting a silently-shorter result set.

```python
from db_eplusout_reader.exceptions import VariableNotFound

# default: missing variables are silently skipped (unchanged behaviour)
get_results(path, [present, missing], frequency=H)            # -> 1 result

# strict: raises listing what was missing
get_results(path, [present, missing], frequency=H, strict=True)
# VariableNotFound: Requested variable(s) not found: Variable(key='NOPE', ...)
```

`strict=False` is added to the public `get_results`, `DBEsoFile.get_results`, and `get_results_from_sql`. Works for both `.sql` and `.eso` inputs.

## Implementation

- New `VariableNotFound` exception + a shared `raise_if_missing()` helper so the message is identical across both readers.
- Both readers now report per-request misses: `_match_variables` (ESO) and `get_ids_dict` (SQL) return a `not_found` list alongside the matches. A request counts as found if it matches **at least one** output, so wildcard requests (`Variable(None, None, None)`) behave naturally.
- Default behaviour is unchanged — the not-found list is only consulted when `strict=True`.

## Tests

`TestSqlStrict` and `TestEsoStrict`: present-variable passes, missing-variable raises (with the missing variable named in the message), non-strict still silently skips, and a missing-everything request raises. Full suite: **131 passed**; ruff clean. README gains a short "Strict Mode" note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
